### PR TITLE
adds the instance method to library

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,34 +46,47 @@ This is the default export of react-native-test-utils. You pass in JSX as the pa
 The `query`, `queryAll`, `toJSON`, and `update` methods are only available on the root view component that gets returned from `renderer`. They are not available on sub views in the react tree.
 
 ### `query(string): ComponentApi`
+
 Similar to `querySelector` in a browser. Pass in a string that is a css selector. It will return the first view in the tree that matches that selector. The returns a component api that matches the return value of `renderer` except that it does not include methods only available on the top level component.
 
 ### `queryAll(string): Array<ComponentApi>`
+
 Similar to `querySelectorAll` in a browser. Pass in a string that is a css selector. It will return an array of all the views that match the selector. Each item in the array is a component api that matches the return value of `renderer` except that it does not includeonly available on the top level component.
 
 `query` and `queryAll` currently only support a subset of css selectors. Currently it supports:
- - Tag name `'TextInput'`
- - Attributes(Props) `"[placeholder='some text']"`
- - Id(testID) `'#my-component.text-input'`
 
- These can also be used together such as `"TextInput[placeholder='some text']"` and it also supports compound selectors `'Text, View'`
+* Tag name `'TextInput'`
+* Attributes(Props) `"[placeholder='some text']"`
+* Id(testID) `'#my-component.text-input'`
+
+These can also be used together such as `"TextInput[placeholder='some text']"` and it also supports compound selectors `'Text, View'`
 
 ### `update(ReactElement/JSX): void`
+
 This method allows you to trigger another render into the same rendering context. Pass in JSX just as you would with `renderer`. This method is useful for cases where you want to test different render trees that may need to make changes to state in a react life cycle method such as `componentWillReceiveProps`. It does not return anything. After calling this method any previous components retrieved using `query` or `queryAll` will no longer be up to date and you will need to get those components again.
 
 ### `toJSON(): any`
+
 Returns an object representation of the entire tree. Useful for matching to a snapshot.
 
 The remaining methods and properties are on every component api returned from calls to `query` and `queryAll`
 
 ### `simulate(string, any): void`
+
 If a component responds to any kind of event that takes a handler as a `on*` property such as `onChange` or `onPress`, you can use `simulate` to trigger that event. The first parameter is the event you would like to trigger and the second parameter is the value you passed into the event handler. eg. `view.simulate('press', {})` After calling `simulate` if the rendered output changes, any component retrieved using `query` and `queryAll` may be out of date and it will be necessary to fetch them again.
 
 ### `text(): string`
+
 Will return all of the rendered text that component or any of it's subviews render as children.
 
 ### `props: any`
+
 The props passed to that component.
 
-### `instance: any`
+### `instance(): any`
+
 The underlying instance of the component that got rendered.
+
+### `component`
+
+The component rendered from react-test-renderer

--- a/README.md
+++ b/README.md
@@ -40,53 +40,48 @@ This is the default export of react-native-test-utils. You pass in JSX as the pa
       simulate,
       text,
       props,
-      instance
+      instance,
+      component,
+      state
     }
 
 The `query`, `queryAll`, `toJSON`, and `update` methods are only available on the root view component that gets returned from `renderer`. They are not available on sub views in the react tree.
 
 ### `query(string): ComponentApi`
-
 Similar to `querySelector` in a browser. Pass in a string that is a css selector. It will return the first view in the tree that matches that selector. The returns a component api that matches the return value of `renderer` except that it does not include methods only available on the top level component.
 
 ### `queryAll(string): Array<ComponentApi>`
-
 Similar to `querySelectorAll` in a browser. Pass in a string that is a css selector. It will return an array of all the views that match the selector. Each item in the array is a component api that matches the return value of `renderer` except that it does not includeonly available on the top level component.
 
 `query` and `queryAll` currently only support a subset of css selectors. Currently it supports:
+ - Tag name `'TextInput'`
+ - Attributes(Props) `"[placeholder='some text']"`
+ - Id(testID) `'#my-component.text-input'`
 
-* Tag name `'TextInput'`
-* Attributes(Props) `"[placeholder='some text']"`
-* Id(testID) `'#my-component.text-input'`
-
-These can also be used together such as `"TextInput[placeholder='some text']"` and it also supports compound selectors `'Text, View'`
+ These can also be used together such as `"TextInput[placeholder='some text']"` and it also supports compound selectors `'Text, View'`
 
 ### `update(ReactElement/JSX): void`
-
 This method allows you to trigger another render into the same rendering context. Pass in JSX just as you would with `renderer`. This method is useful for cases where you want to test different render trees that may need to make changes to state in a react life cycle method such as `componentWillReceiveProps`. It does not return anything. After calling this method any previous components retrieved using `query` or `queryAll` will no longer be up to date and you will need to get those components again.
 
 ### `toJSON(): any`
-
 Returns an object representation of the entire tree. Useful for matching to a snapshot.
 
 The remaining methods and properties are on every component api returned from calls to `query` and `queryAll`
 
 ### `simulate(string, any): void`
-
 If a component responds to any kind of event that takes a handler as a `on*` property such as `onChange` or `onPress`, you can use `simulate` to trigger that event. The first parameter is the event you would like to trigger and the second parameter is the value you passed into the event handler. eg. `view.simulate('press', {})` After calling `simulate` if the rendered output changes, any component retrieved using `query` and `queryAll` may be out of date and it will be necessary to fetch them again.
 
 ### `text(): string`
-
 Will return all of the rendered text that component or any of it's subviews render as children.
 
 ### `props: any`
-
 The props passed to that component.
 
 ### `instance(): any`
-
 The underlying instance of the component that got rendered.
 
 ### `component`
-
 The component rendered from react-test-renderer
+
+### `state(): any`
+Retreives the state of the current instance of the component.

--- a/index.js
+++ b/index.js
@@ -1,64 +1,76 @@
-import renderer from 'react-test-renderer'
-import find from './find'
-import { CssSelectorParser } from 'css-selector-parser'
+import renderer from "react-test-renderer";
+import find from "./find";
+import { CssSelectorParser } from "css-selector-parser";
 
-const PARSER = new CssSelectorParser()
-PARSER.registerAttrEqualityMods('^', '$', '*', '|')
+const PARSER = new CssSelectorParser();
+PARSER.registerAttrEqualityMods("^", "$", "*", "|");
 
 function eventSimulator(props, eventName, event) {
-  return function () {
-    props[eventName](event)
-  }
+  return function() {
+    props[eventName](event);
+  };
 }
 
-function createApi (tree) {
-  if (!tree) return null
+function createApi(tree) {
+  if (!tree) return null;
   return {
     props: tree.props,
 
-    simulate (eventName, event) {
-      let eventHandlerName = `on${eventName[0].toUpperCase()}${eventName.substring(1)}`
+    simulate(eventName, event) {
+      let eventHandlerName = `on${eventName[0].toUpperCase()}${eventName.substring(
+        1
+      )}`;
 
       if (!tree.props[eventHandlerName]) {
-        throw new Error(`Event ${eventName} not handled`)
+        throw new Error(`Event ${eventName} not handled`);
       }
 
-      tree.props[eventHandlerName](event)
+      tree.props[eventHandlerName](event);
     },
 
-    text () {
+    text() {
       return find(tree, {
-        type: 'custom',
-        match: (tree) => {
-          let children = Array.isArray(tree.children) ? tree.children : [tree.children]
-          return children.some(child => typeof child === 'string')
+        type: "custom",
+        match: tree => {
+          let children = Array.isArray(tree.children)
+            ? tree.children
+            : [tree.children];
+          return children.some(child => typeof child === "string");
         }
-      }).map(({ children }) => {
-        let arrayChildren = Array.isArray(children) ? children : [children]
-        return arrayChildren
-          .filter(child => typeof child === 'string')
-          .join('')
       })
-      .join('')
+        .map(({ children }) => {
+          let arrayChildren = Array.isArray(children) ? children : [children];
+          return arrayChildren
+            .filter(child => typeof child === "string")
+            .join("");
+        })
+        .join("");
     }
-  }
+  };
 }
 
-export default function (component) {
-  let view = renderer.create(component)
+export default function(component) {
+  let view = renderer.create(component);
   return {
-    query (selector) {
-      selector = selector.replace('.', '\\.')
-      let parsed = PARSER.parse(selector)
-      return createApi(find(view.toJSON(), parsed)[0])
+    component: view,
+    instance() {
+      return view.getInstance();
     },
-    queryAll (selector) {
-      selector = selector.replace('.', '\\.')
-      let parsed = PARSER.parse(selector)
-      return find(view.toJSON(), parsed).map(createApi)
+    state() {
+      return view.getInstance().state;
+    },
+    query(selector) {
+      selector = selector.replace(".", "\\.");
+      let parsed = PARSER.parse(selector);
+      return createApi(find(view.toJSON(), parsed)[0]);
+    },
+    queryAll(selector) {
+      selector = selector.replace(".", "\\.");
+      let parsed = PARSER.parse(selector);
+      return find(view.toJSON(), parsed).map(createApi);
     },
     update: view.update,
     toJSON: view.toJSON,
     ...createApi(view.toJSON())
-  }
+  };
 }

--- a/index.js
+++ b/index.js
@@ -1,76 +1,67 @@
-import renderer from "react-test-renderer";
-import find from "./find";
-import { CssSelectorParser } from "css-selector-parser";
+import renderer from 'react-test-renderer'
+import find from './find'
+import { CssSelectorParser } from 'css-selector-parser'
 
-const PARSER = new CssSelectorParser();
-PARSER.registerAttrEqualityMods("^", "$", "*", "|");
+const PARSER = new CssSelectorParser()
+PARSER.registerAttrEqualityMods('^', '$', '*', '|')
 
 function eventSimulator(props, eventName, event) {
-  return function() {
-    props[eventName](event);
-  };
+  return function () {
+    props[eventName](event)
+  }
 }
 
-function createApi(tree) {
-  if (!tree) return null;
+function createApi (tree) {
+  if (!tree) return null
   return {
     props: tree.props,
 
-    simulate(eventName, event) {
-      let eventHandlerName = `on${eventName[0].toUpperCase()}${eventName.substring(
-        1
-      )}`;
+    simulate (eventName, event) {
+      let eventHandlerName = `on${eventName[0].toUpperCase()}${eventName.substring(1)}`
 
       if (!tree.props[eventHandlerName]) {
-        throw new Error(`Event ${eventName} not handled`);
+        throw new Error(`Event ${eventName} not handled`)
       }
 
-      tree.props[eventHandlerName](event);
+      tree.props[eventHandlerName](event)
     },
 
-    text() {
+    text () {
       return find(tree, {
-        type: "custom",
-        match: tree => {
-          let children = Array.isArray(tree.children)
-            ? tree.children
-            : [tree.children];
-          return children.some(child => typeof child === "string");
+        type: 'custom',
+        match: (tree) => {
+          let children = Array.isArray(tree.children) ? tree.children : [tree.children]
+          return children.some(child => typeof child === 'string')
         }
+      }).map(({ children }) => {
+        let arrayChildren = Array.isArray(children) ? children : [children]
+        return arrayChildren
+          .filter(child => typeof child === 'string')
+          .join('')
       })
-        .map(({ children }) => {
-          let arrayChildren = Array.isArray(children) ? children : [children];
-          return arrayChildren
-            .filter(child => typeof child === "string")
-            .join("");
-        })
-        .join("");
+      .join('')
     }
-  };
+  }
 }
 
-export default function(component) {
-  let view = renderer.create(component);
+export default function (component) {
+  let view = renderer.create(component)
   return {
     component: view,
-    instance() {
-      return view.getInstance();
+    instance () { return view.getInstance() },
+    state () { return view.getInstance().state },
+    query (selector) {
+      selector = selector.replace('.', '\\.')
+      let parsed = PARSER.parse(selector)
+      return createApi(find(view.toJSON(), parsed)[0])
     },
-    state() {
-      return view.getInstance().state;
-    },
-    query(selector) {
-      selector = selector.replace(".", "\\.");
-      let parsed = PARSER.parse(selector);
-      return createApi(find(view.toJSON(), parsed)[0]);
-    },
-    queryAll(selector) {
-      selector = selector.replace(".", "\\.");
-      let parsed = PARSER.parse(selector);
-      return find(view.toJSON(), parsed).map(createApi);
+    queryAll (selector) {
+      selector = selector.replace('.', '\\.')
+      let parsed = PARSER.parse(selector)
+      return find(view.toJSON(), parsed).map(createApi)
     },
     update: view.update,
     toJSON: view.toJSON,
     ...createApi(view.toJSON())
-  };
+  }
 }


### PR DESCRIPTION
I found this cool little library and I started playing with it, and I realized the `instance` method was not implemented... so I implemented it.

Here is an example of how I am using it:
```
  it('expands nodes when selected', () => {
    jest.mock('TouchableHighlight', () => 'TouchableHighlight');

    const component = renderer(<ScopeTree scope={scopeMockGraph} />);
    expect(component.state().expanded).toEqual(false);
    const expandComponent = component.query('#expandIcon');
    expandComponent.simulate('press');
    expect(component.state().expanded).toEqual(true);
  });
```

It looks like my eslint settings autofixed things to my format, and not yours.  If you'd like this changed, please let me know.