### PR TITLE
stop simulate if component is disabled

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,8 +15,11 @@ function createApi (tree) {
   if (!tree) return null
   return {
     props: tree.props,
-
     simulate (eventName, event) {
+      if (tree.props.disabled) {
+        return
+      }
+
       let eventHandlerName = `on${eventName[0].toUpperCase()}${eventName.substring(1)}`
 
       if (!tree.props[eventHandlerName]) {


### PR DESCRIPTION
It should handle the `simulate` issue when `disabled` is `true` in this comment: https://github.com/shichongrui/react-native-test-utils/issues/8#issuecomment-366207135